### PR TITLE
Error handling for summer semester

### DIFF
--- a/get_assessment.py
+++ b/get_assessment.py
@@ -17,7 +17,7 @@ class CourseNotFoundError(Exception):
 class WrongSemesterError(Exception):
     def __init__(self, course: str, sem: str):
         self.message = f"The course '{course}' does not exist in the selected semester. (Semester {sem})"
-        if sem == 3:
+        if sem == "3":
             self.message = f"The course '{course}' does not exist in the summer semester."
         super().__init__(self.message)
 


### PR DESCRIPTION
Fixed error message to say "summer semester" instead of "semester 3" when a course is not available.