### PR TITLE
Toggle for Assessment Items + Handling new ECP format

### DIFF
--- a/get_assessment.py
+++ b/get_assessment.py
@@ -53,7 +53,12 @@ def get_page(code:str, semester:str , year:str):
             return href
 
 
-def get_table(section_code):
+def get_table_old(section_code):
+    """Get table for courses before 2024 Semester 2
+
+    Args:
+        section_code (str): Course code
+    """
     headers = requests.utils.default_headers()
     headers.update(
         {
@@ -91,13 +96,71 @@ def get_table(section_code):
     df.loc[df['Assessment Task'].str.contains("||"), ['Assessment Task']] = df['Assessment Task'].str.partition('||')[0]
     return list(df.itertuples(index=False, name=None))
 
+def get_table(semester, year, section_code):
+    """Gets the assessment items for courses
+
+    Args:
+        semester (int): Semester for course
+        year (int): year for course
+        section_code (str): Course code
+    """
+    headers = requests.utils.default_headers()
+    headers.update(
+        {
+            'User-Agent': 'My User Agent 1.0',
+        }
+    )
+    
+    # For previous semesters, use old version of course profile
+    if (year == 2024 and semester == 1)or year < 2024:
+        return get_table_old(section_code)
+    
+    url = f'https://course-profiles.uq.edu.au/course-profiles/{section_code}#assessment'
+    page = requests.get(url, headers=headers)
+    html_content = page.text
+    soup = BeautifulSoup(html_content, 'html.parser')
+
+    # Remove <ul class="icon-list"> elements
+    for ul in soup.find_all('ul', class_='icon-list'):
+        ul.decompose()
+    
+    # Extract table headings + rows for pandas df
+    table = soup.find('table')
+    headers = [header.text.strip() for header in table.find_all('th')]
+    rows = []
+    for row in table.find('tbody').find_all('tr'):
+        cols = row.find_all('td')
+        rows.append([col.text.strip() for col in cols])
+        
+    df = pd.DataFrame(rows, columns=headers)
+    df = df.drop(columns=["Category", "Due date"])
+
+    # Edge case where weight = 0% and UQ left the weight 'blank'
+    df = df.dropna()
+    df['Weight'] = df['Weight'].astype(str)
+    
+    # Edge Case: Identify rows where Weighting does not contain "%" (e.g. DECO2200, DECO7200)
+    non_percentage_rows = df.loc[~df['Weight'].str.contains("%"), 'Weight']
+    
+    # If all entries are numeric and equal, convert them to percentages
+    if len(non_percentage_rows) > 0 and non_percentage_rows.apply(lambda x: x.isdigit()).all():
+        total_tasks = len(non_percentage_rows)
+        percentage = 100 / total_tasks
+        df.loc[~df['Weight'].str.contains("%"), 'Weight'] = f"{percentage:.2f}%"
+
+    # Convert weightings to the appropriate format.
+    df.loc[df['Weight'].str.contains("%"), ['Weight']] = df['Weight'].str.partition('%')[0]  + "%"
+    return list(df.itertuples(index=False, name=None))
+
 
 def get_assessments(code:str, semester:str, year:str):
     course_profile = get_page(code, semester, year)
     if course_profile is None:
         raise WrongSemesterError(code, semester)
     section_code = course_profile.rpartition('/')[2]
-    table = get_table(section_code)
+    year = int(year)
+    semester = int(semester)
+    table = get_table(semester, year, section_code)
 
     # send to discord
     headers = requests.utils.default_headers()

--- a/static/css/bulma-switch-main.css
+++ b/static/css/bulma-switch-main.css
@@ -1,0 +1,596 @@
+/* Bulma Utilities */
+.switch {
+  -webkit-touch-callout: none;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+/* Box-shadow */
+.switch {
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  position: relative;
+  margin-right: 0.5em;
+}
+
+.switch + .switch:last-child {
+  margin-right: 0;
+}
+
+.switch input[type=checkbox] {
+  position: absolute;
+  left: 0;
+  opacity: 0;
+  outline: none;
+  z-index: -1;
+}
+
+.switch input[type=checkbox] + .check {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  width: 2.75em;
+  height: 1.575em;
+  padding: 0.2em;
+  background: #b5b5b5;
+  border-radius: 4px;
+  transition: background 150ms ease-out, box-shadow 150ms ease-out;
+}
+
+.switch input[type=checkbox] + .check.is-white-passive, .switch input[type=checkbox] + .check:hover {
+  background: white;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-black-passive, .switch input[type=checkbox] + .check:hover {
+  background: #0a0a0a;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-light-passive, .switch input[type=checkbox] + .check:hover {
+  background: whitesmoke;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-dark-passive, .switch input[type=checkbox] + .check:hover {
+  background: #363636;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-primary-passive, .switch input[type=checkbox] + .check:hover {
+  background: #00d1b2;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-link-passive, .switch input[type=checkbox] + .check:hover {
+  background: #485fc7;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-info-passive, .switch input[type=checkbox] + .check:hover {
+  background: #3e8ed0;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-success-passive, .switch input[type=checkbox] + .check:hover {
+  background: #48c78e;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-warning-passive, .switch input[type=checkbox] + .check:hover {
+  background: #ffe08a;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check.is-danger-passive, .switch input[type=checkbox] + .check:hover {
+  background: #f14668;
+}
+
+.switch input[type=checkbox] + .check.input[type=checkbox] + .switch input[type=checkbox] + .check.check {
+  background: 'pink';
+}
+
+.switch input[type=checkbox] + .check:before {
+  content: "";
+  display: block;
+  border-radius: 4px;
+  width: 1.175em;
+  height: 1.175em;
+  background: whitesmoke;
+  transition: transform 150ms ease-out;
+  will-change: transform;
+  transform-origin: left;
+}
+
+.switch input[type=checkbox] + .check.is-elastic:before {
+  transform: scaleX(1.5);
+  border-radius: 4px;
+}
+
+.switch input[type=checkbox]:checked + .check {
+  background: #B461FF;
+}
+
+.switch input[type=checkbox]:checked + .check.is-white {
+  background: white;
+}
+
+.switch input[type=checkbox]:checked + .check.is-black {
+  background: #0a0a0a;
+}
+
+.switch input[type=checkbox]:checked + .check.is-light {
+  background: whitesmoke;
+}
+
+.switch input[type=checkbox]:checked + .check.is-dark {
+  background: #363636;
+}
+
+.switch input[type=checkbox]:checked + .check.is-primary {
+  background: #00d1b2;
+}
+
+.switch input[type=checkbox]:checked + .check.is-link {
+  background: #485fc7;
+}
+
+.switch input[type=checkbox]:checked + .check.is-info {
+  background: #3e8ed0;
+}
+
+.switch input[type=checkbox]:checked + .check.is-success {
+  background: #48c78e;
+}
+
+.switch input[type=checkbox]:checked + .check.is-warning {
+  background: #ffe08a;
+}
+
+.switch input[type=checkbox]:checked + .check.is-danger {
+  background: #f14668;
+}
+
+.switch input[type=checkbox]:checked + .check:before {
+  transform: translate3d(100%, 0, 0);
+}
+
+.switch input[type=checkbox]:checked + .check.is-elastic:before {
+  transform: translate3d(50%, 0, 0) scaleX(1.5);
+}
+
+.switch input[type=checkbox]:focus, .switch input[type=checkbox]:active {
+  outline: none;
+}
+
+.switch .control-label {
+  padding-left: 0.5em;
+}
+
+.switch:hover input[type=checkbox] + .check {
+  background: rgba(181, 181, 181, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-white-passive {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-black-passive {
+  background: rgba(10, 10, 10, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-light-passive {
+  background: rgba(245, 245, 245, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-dark-passive {
+  background: rgba(54, 54, 54, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-primary-passive {
+  background: rgba(0, 209, 178, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-link-passive {
+  background: rgba(72, 95, 199, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-info-passive {
+  background: rgba(62, 142, 208, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-success-passive {
+  background: rgba(72, 199, 142, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-warning-passive {
+  background: rgba(255, 224, 138, 0.9);
+}
+
+.switch:hover input[type=checkbox] + .check.is-danger-passive {
+  background: rgba(241, 70, 104, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check {
+  background: rgba(186, 117, 255, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-white {
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-black {
+  background: rgba(10, 10, 10, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-light {
+  background: rgba(245, 245, 245, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-dark {
+  background: rgba(54, 54, 54, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-primary {
+  background: rgba(0, 209, 178, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-link {
+  background: rgba(72, 95, 199, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-info {
+  background: rgba(62, 142, 208, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-success {
+  background: rgba(72, 199, 142, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-warning {
+  background: rgba(255, 224, 138, 0.9);
+}
+
+.switch:hover input[type=checkbox]:checked + .check.is-danger {
+  background: rgba(241, 70, 104, 0.9);
+}
+
+.switch.is-rounded input[type=checkbox] + .check {
+  border-radius: 9999px;
+}
+
+.switch.is-rounded input[type=checkbox] + .check:before {
+  border-radius: 9999px;
+}
+
+.switch.is-rounded input[type=checkbox].is-elastic:before {
+  transform: scaleX(1.5);
+  border-radius: 9999px;
+}
+
+.switch.is-outlined input[type=checkbox] + .check {
+  background: transparent;
+  border: 0.1rem solid #b5b5b5;
+  padding: 0.1em;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-white-passive {
+  border: 0.1rem solid rgba(255, 255, 255, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-white-passive:before {
+  background: white;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-white-passive:hover {
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-black-passive {
+  border: 0.1rem solid rgba(10, 10, 10, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-black-passive:before {
+  background: #0a0a0a;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-black-passive:hover {
+  border-color: rgba(10, 10, 10, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-light-passive {
+  border: 0.1rem solid rgba(245, 245, 245, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-light-passive:before {
+  background: whitesmoke;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-light-passive:hover {
+  border-color: rgba(245, 245, 245, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-dark-passive {
+  border: 0.1rem solid rgba(54, 54, 54, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-dark-passive:before {
+  background: #363636;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-dark-passive:hover {
+  border-color: rgba(54, 54, 54, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-primary-passive {
+  border: 0.1rem solid rgba(0, 209, 178, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-primary-passive:before {
+  background: #00d1b2;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-primary-passive:hover {
+  border-color: rgba(0, 209, 178, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-link-passive {
+  border: 0.1rem solid rgba(72, 95, 199, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-link-passive:before {
+  background: #485fc7;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-link-passive:hover {
+  border-color: rgba(72, 95, 199, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-info-passive {
+  border: 0.1rem solid rgba(62, 142, 208, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-info-passive:before {
+  background: #3e8ed0;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-info-passive:hover {
+  border-color: rgba(62, 142, 208, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-success-passive {
+  border: 0.1rem solid rgba(72, 199, 142, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-success-passive:before {
+  background: #48c78e;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-success-passive:hover {
+  border-color: rgba(72, 199, 142, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-warning-passive {
+  border: 0.1rem solid rgba(255, 224, 138, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-warning-passive:before {
+  background: #ffe08a;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-warning-passive:hover {
+  border-color: rgba(255, 224, 138, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-danger-passive {
+  border: 0.1rem solid rgba(241, 70, 104, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-danger-passive:before {
+  background: #f14668;
+}
+
+.switch.is-outlined input[type=checkbox] + .check.is-danger-passive:hover {
+  border-color: rgba(241, 70, 104, 0.9);
+}
+
+.switch.is-outlined input[type=checkbox] + .check:before {
+  background: #b5b5b5;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check {
+  border-color: #00d1b2;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-white {
+  background: transparent;
+  border-color: white;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-white:before {
+  background: white;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-black {
+  background: transparent;
+  border-color: #0a0a0a;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-black:before {
+  background: #0a0a0a;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-light {
+  background: transparent;
+  border-color: whitesmoke;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-light:before {
+  background: whitesmoke;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-dark {
+  background: transparent;
+  border-color: #363636;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-dark:before {
+  background: #363636;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-primary {
+  background: transparent;
+  border-color: #00d1b2;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-primary:before {
+  background: #00d1b2;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-link {
+  background: transparent;
+  border-color: #485fc7;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-link:before {
+  background: #485fc7;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-info {
+  background: transparent;
+  border-color: #3e8ed0;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-info:before {
+  background: #3e8ed0;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-success {
+  background: transparent;
+  border-color: #48c78e;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-success:before {
+  background: #48c78e;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-warning {
+  background: transparent;
+  border-color: #ffe08a;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-warning:before {
+  background: #ffe08a;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-danger {
+  background: transparent;
+  border-color: #f14668;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check.is-danger:before {
+  background: #f14668;
+}
+
+.switch.is-outlined input[type=checkbox]:checked + .check:before {
+  background: #00d1b2;
+}
+
+.switch.is-outlined:hover input[type=checkbox] + .check {
+  background: transparent;
+  border-color: rgba(181, 181, 181, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check {
+  background: transparent;
+  border-color: rgba(0, 209, 178, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-white {
+  border-color: rgba(255, 255, 255, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-black {
+  border-color: rgba(10, 10, 10, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-light {
+  border-color: rgba(245, 245, 245, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-dark {
+  border-color: rgba(54, 54, 54, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-primary {
+  border-color: rgba(0, 209, 178, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-link {
+  border-color: rgba(72, 95, 199, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-info {
+  border-color: rgba(62, 142, 208, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-success {
+  border-color: rgba(72, 199, 142, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-warning {
+  border-color: rgba(255, 224, 138, 0.9);
+}
+
+.switch.is-outlined:hover input[type=checkbox]:checked + .check.is-danger {
+  border-color: rgba(241, 70, 104, 0.9);
+}
+
+.switch.is-small {
+  border-radius: 2px;
+  font-size: 0.75rem;
+}
+
+.switch.is-medium {
+  font-size: 1.25rem;
+}
+
+.switch.is-large {
+  font-size: 1.5rem;
+}
+
+.switch[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+  color: #7a7a7a;
+}

--- a/static/css/index_style.css
+++ b/static/css/index_style.css
@@ -47,6 +47,7 @@
 
 .content-font {
   font-family: contentFont;
+  letter-spacing: 0.05em;
 }
 
 .title-font {
@@ -73,6 +74,18 @@ body {
   padding-right: 9%;
 }
 
+.warning-msg {
+  width: 82%;
+}
+.is-warning-msg{
+  background-color: #FFD700;
+}
+
+p.is-warning-msg {
+  color: #000;
+  letter-spacing: 0.05em !important;
+}
+
 .hero{
   color: rgb(255,255,255);
   padding-top: 50px;
@@ -96,12 +109,20 @@ body {
   border-width: 5px;
 }
 
+p.is-danger {
+  color: #FBE0E5;
+}
+
 #analytics-mobile-block {
   display: none;
 }
 
 @media only screen and (max-width: 768px) {
   table{
+    width: 90% !important;
+  }
+
+  .warning-msg{
     width: 90% !important;
   }
 
@@ -173,6 +194,7 @@ div {
   border-radius: 6px;
   background-color:#F4EAFF;
   text-align: center;
+  width: 82%;
 }
 
 .rounded-corner {
@@ -185,6 +207,13 @@ div {
   border-radius: 6px;
   border-color: #000;
   font-size: 16px;
+}
+
+.score-input:disabled {
+  background-color: #A9A9A9; /* Light grey background */
+  border-color: #000;
+  color: #6c757d; /* Grey text color */
+  cursor: not-allowed; /* Change cursor to indicate disabled state */
 }
 
 .figure {
@@ -303,4 +332,30 @@ th {
 #analytics-iframe {
   padding: 0;
   margin-bottom: -10px;
+}
+
+.switch-div {
+  align-items: center;
+  justify-content: center;
+}
+
+
+/* Icon on left, Text is centered for warnings*/
+#invalid-weight-warning {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-radius: 6px;
+}
+
+#invalid-weight-warning .fas {
+  margin-right: 10px;
+  color: #000000;
+}
+
+#invalid-weight-warning p {
+  flex-grow: 1;
+  margin: 0;
+  text-align: center;
+  font-weight: bold;
 }

--- a/static/js/course.js
+++ b/static/js/course.js
@@ -2,7 +2,7 @@ const scores = document.getElementsByName("score");
 
 function calculate(){
   let total_score = 0.00
-  let undecided = 0.00
+  let decided = 0.00
   for (let i = 0; i < scores.length; i++) {
     let weight = parseFloat((scores[i].dataset.weight))
     if (scores[i].disabled === false) {
@@ -50,12 +50,14 @@ function calculate(){
           scores[i].value = score  + "%"
         }
         total_score += score*(weight/100);
-      } else if (scores[i].disabled === false) {
-        undecided += weight/100
-      }
+        decided += weight/100;
+      } 
    }
   }
 
+  // Cap required calculated score to be 100 marks maximum. (e.g. cannot be 1/101 required)
+  // Useful for courses with optional marks / best out of X quizes.
+  let undecided = Math.max(1-decided, 0); 
 
 
 

--- a/static/js/course.js
+++ b/static/js/course.js
@@ -1,11 +1,16 @@
 const scores = document.getElementsByName("score");
+const score_switches = document.getElementsByName("score-switch");
 
 function calculate(){
   let total_score = 0.00
   let decided = 0.00
+  let total_weights = 0.00
   for (let i = 0; i < scores.length; i++) {
     let weight = parseFloat((scores[i].dataset.weight))
-    if (scores[i].disabled === false) {
+    if (scores[i].disabled === true) {
+      continue
+    }
+    else {
       var resultArray = scores[i].value.split("/");
 
       if (resultArray.length != 2 
@@ -52,7 +57,16 @@ function calculate(){
         total_score += score*(weight/100);
         decided += weight/100;
       } 
+      total_weights += weight/100;
    }
+  }
+
+  // Check if total weights of items != 100 marks
+  if (total_weights < 1) {
+    document.getElementById("invalid-weight-warning").classList.remove('is-hidden');
+  }
+  else {
+    document.getElementById("invalid-weight-warning").classList.add('is-hidden');
   }
 
   // Cap required calculated score to be 100 marks maximum. (e.g. cannot be 1/101 required)
@@ -89,15 +103,33 @@ function calculate(){
   return false;
 }
 
+function toggleDisable(checkbox) {
+  const scoreInput = checkbox.closest('tr').querySelector('.score-input');
+  scoreInput.disabled = ! checkbox.checked;
+  calculate(); // Re-calculate with updated weights.
+}
+
 function onStart() {
   for (let i = 0; i < scores.length; i++) {
     if (scores[i].dataset.weight.toLowerCase().indexOf("%") === -1) {
       scores[i].disabled = true;
+      scores[i].title = "A VALID percentage weight format has not been detected.";
+      score_switches[i].disabled = true;
+      score_switches[i].checked = false;
+      score_switches[i].title = "A VALID percentage weight format has not been detected.";
     }
     else if (scores[i].dataset.weight.toLowerCase() == "0%") {
       scores[i].disabled = true;
+      scores[i].title = "A VALID percentage weight format has not been detected.";
+      score_switches[i].disabled = true;
+      score_switches[i].checked = false;
+      score_switches[i].title = "A VALID percentage weight format has not been detected.";
     }
   }
+  calculate();
 return false;
 }
-onStart();
+
+document.addEventListener('DOMContentLoaded', function() {
+  onStart();
+});

--- a/templates/course_code.html
+++ b/templates/course_code.html
@@ -14,6 +14,8 @@
     <link rel="icon" type="image/png" sizes="512x512" href="{{ url_for('static', filename='images/android-chrome-512x512.png') }}">
     <link rel="preload" href="{{url_for('static', filename='fonts//RedHatDisplay-Regular.ttf')}}" as="font">
     <link rel="preload" href="{{url_for('static', filename='fonts///Sato-Medium.ttf')}}" as="font">
+    <link rel="stylesheet" href="{{url_for('static', filename='css/bulma-switch-main.css')}}">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.4/css/all.min.css">
     <meta name="robots" content="noindex">
         <meta property='og:title'  content='UQ Grade Calculator'>
     <meta property='og:url'  content='https://www.uqmarks.com/'>
@@ -105,27 +107,41 @@
         </div>
       </div>
         <div class="container" id="tblresults">
-          <table class="table" style="width: 82%">
+          <table class="table">
             <colgroup>
               <col span="1" style="width: 50%;">
+              <col span="1" style="width: 20%;">
               <col span="1" style="width: 25%;">
-              <col span="1" style="width: 25%;">
+              <col span="1" style="width: 5%;">
             </colgroup>
             <thead>
               <th>Assessment</th>
               <th>Weight</th>
               <th>Your Score</th>
+              <th></th>
             </thead>
             {% for name, weight in assessment_list %}
             <tr>
                 <td>{{ name }}</td>
                 <td>{{ weight }}</td>
                 <td><input onchange="calculate()" data-weight={{weight}} name="score" class="input score-input" type="text" placeholder="90, 90% or 9/10" style="width: 100%;"></td>
+                <td>
+                  <label class="switch is-rounded is-medium">
+                    <input name="score-switch" type="checkbox" value="false" checked="" onclick="toggleDisable(this)">
+                    <span class="check"></span>
+                  </label>
+                </td>
             </tr>
             {% endfor %}
           </table>
         </div>
-
+        <br>
+        <div class="container warning-msg">
+          <div id="invalid-weight-warning" class="notification is-warning-msg is-hidden">
+            <i class="fas fa-exclamation-triangle"></i>
+            <p class="is-warning-msg has-text-weight-semibold content-font">The assessment items do not add up to 100%.</p>
+          </div>
+        </div>
         <div class="results-container">
         <br>
         
@@ -135,7 +151,7 @@
         </div>
         <br>
         <div class="container">
-          <table class="table" style="width: 82%">
+          <table class="table">
             <colgroup>
               <col span="1" style="width: 25%;">
               <col span="1" style="width: 25%;">

--- a/templates/invalid.html
+++ b/templates/invalid.html
@@ -90,7 +90,7 @@
               <div class="column">
                 <p class="control ccode">
                   <input name='CourseCode' value={{code}} class="input is-medium is-danger content-font" type="text" placeholder="Course Code" autocomplete="off" spellcheck="false" autofocus >
-                  <p class="help is-danger is-size-6 content-font">{{invalid_text}}</p>
+                  <p class="is-danger is-size-6 content-font">{{invalid_text}}</p>
                 </p>
               </div>
               <div class="column is-one-fifth">


### PR DESCRIPTION
- Added toggles for each assessment items. This is useful for when courses have "best 5 out of 6" assessment items and displays each one in the ECP. (e.g. ECON1010)
- Results for assessments are capped at 100%.
- Added new logic to handle new ECP format. Legacy ECP (before 2024s2) are still able to be accessed 